### PR TITLE
fix: specify title for home page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -6,7 +6,11 @@ import { NumbersGameComponent } from './numbers-game/numbers-game.component';
 import { SettingsComponent } from './settings/settings.component';
 
 const routes: Routes = [
-  { path: '', component: GameSelectionComponent },
+  {
+    path: '',
+    component: GameSelectionComponent,
+    title: 'Game Selection | Conundrum',
+  },
   {
     path: 'letters-game',
     component: LettersGameComponent,
@@ -25,9 +29,11 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes, {
-    initialNavigation: 'enabledBlocking'
-})],
+  imports: [
+    RouterModule.forRoot(routes, {
+      initialNavigation: 'enabledBlocking',
+    }),
+  ],
   exports: [RouterModule],
 })
 export class AppRoutingModule {}


### PR DESCRIPTION
This fixes an issue where going to the home page would leave the title the same as whatever page you came from.