### PR TITLE
fix: numbers game cheat

### DIFF
--- a/src/app/numbers-game-combined-numbers/numbers-game-combined-numbers.component.html
+++ b/src/app/numbers-game-combined-numbers/numbers-game-combined-numbers.component.html
@@ -1,6 +1,7 @@
 <button
   type="button"
   *ngFor="let number of combinedNumbers"
+  [attr.data-selected]="number.isSelected"
   (click)="selectNumber.emit(number)"
   [disabled]="state !== 'game-in-progress' || number.isInUse"
 >

--- a/src/app/numbers-game-operators/numbers-game-operators.component.html
+++ b/src/app/numbers-game-operators/numbers-game-operators.component.html
@@ -1,6 +1,7 @@
 <button
   type="button"
   aria-label="Multiply"
+  [attr.data-selected]="operator === 'multiplication'"
   (click)="selectOperator.emit('multiplication')"
   [disabled]="state !== 'game-in-progress' || selectedNumber == null"
 >
@@ -9,6 +10,7 @@
 <button
   type="button"
   aria-label="Divide"
+  [attr.data-selected]="operator === 'division'"
   (click)="selectOperator.emit('division')"
   [disabled]="state !== 'game-in-progress' || selectedNumber == null"
 >
@@ -17,6 +19,7 @@
 <button
   type="button"
   aria-label="Add"
+  [attr.data-selected]="operator === 'addition'"
   (click)="selectOperator.emit('addition')"
   [disabled]="state !== 'game-in-progress' || selectedNumber == null"
 >
@@ -25,6 +28,7 @@
 <button
   type="button"
   aria-label="Subtract"
+  [attr.data-selected]="operator === 'subtraction'"
   (click)="selectOperator.emit('subtraction')"
   [disabled]="state !== 'game-in-progress' || selectedNumber == null"
 >

--- a/src/app/numbers-game-operators/numbers-game-operators.component.ts
+++ b/src/app/numbers-game-operators/numbers-game-operators.component.ts
@@ -9,5 +9,6 @@ import { GameState, Number, ResultOf } from '../numbers';
 export class NumbersGameOperatorsComponent {
   @Input() state!: GameState;
   @Input() selectedNumber!: Number | null;
+  @Input() operator!: ResultOf['operation'] | null;
   @Output() selectOperator = new EventEmitter<ResultOf['operation']>();
 }

--- a/src/app/numbers-game-starting-numbers/numbers-game-starting-numbers.component.html
+++ b/src/app/numbers-game-starting-numbers/numbers-game-starting-numbers.component.html
@@ -2,6 +2,7 @@
   <button
     type="button"
     *ngFor="let number of startingNumbers"
+    [attr.data-selected]="number.isSelected"
     (click)="selectNumber.emit(number)"
     [disabled]="state !== 'game-in-progress' || number.isInUse"
   >

--- a/src/app/numbers-game/numbers-game.component.html
+++ b/src/app/numbers-game/numbers-game.component.html
@@ -17,6 +17,7 @@
 <app-numbers-game-operators
   [state]="state"
   [selectedNumber]="selectedNumber"
+  [operator]="operator"
   (selectOperator)="handleOperatorClick($event)"
 ></app-numbers-game-operators>
 

--- a/src/app/numbers-game/numbers-game.component.ts
+++ b/src/app/numbers-game/numbers-game.component.ts
@@ -202,6 +202,10 @@ export class NumbersGameComponent implements OnInit {
       return;
     }
 
+    if (number.isSelected) {
+      return;
+    }
+
     if (this.operator == null) {
       return;
     }

--- a/src/app/numbers-game/numbers-game.component.ts
+++ b/src/app/numbers-game/numbers-game.component.ts
@@ -216,6 +216,7 @@ export class NumbersGameComponent implements OnInit {
 
     this.doMath(this.selectedNumber, number, this.operator);
     this.selectedNumber = null;
+    this.operator = null;
   }
 
   handleOperatorClick(operator: ResultOf['operation']) {

--- a/src/styles.css
+++ b/src/styles.css
@@ -271,6 +271,11 @@
   button:not([disabled]):focus:not(:focus-visible) {
     outline-color: transparent;
   }
+
+  button[data-selected="true"] {
+    background-color: var(--ink);
+    color: var(--paper);
+  }
 }
 
 @layer components {


### PR DESCRIPTION
This fixes an issue where you could select the same number during an operation, effectively letting you cheat at the numbers game. It also makes it clearer which number and operator are selected as you're doing math.