### PR TITLE
feat: resize buttons and gaps for small screens

### DIFF
--- a/src/app/letters-game-board/letters-game-board.component.css
+++ b/src/app/letters-game-board/letters-game-board.component.css
@@ -5,6 +5,12 @@
   place-content: center;
 }
 
+@media (max-width: 26rem) {
+  :host {
+    gap: var(--size-s-5);
+  }
+}
+
 button {
   text-transform: uppercase;
   font-size: var(--size-s0);

--- a/src/app/letters-game-selected-letters/letters-game-selected-letters.component.css
+++ b/src/app/letters-game-selected-letters/letters-game-selected-letters.component.css
@@ -5,6 +5,12 @@
   justify-content: center;
 }
 
+@media (max-width: 26rem) {
+  .cmp-selected-letters {
+    gap: var(--size-s-5);
+  }
+}
+
 .cmp-selected-letters--radial {
   display: block;
   position: relative;

--- a/src/styles.css
+++ b/src/styles.css
@@ -257,6 +257,12 @@
     background-color: transparent;
   }
 
+  @media (max-width: 36rem) {
+    button {
+      padding: 0.25em 0.5em;
+    }
+  }
+
   button:not([disabled]):hover,
   button:not([disabled]):focus {
     background-color: var(--ink);
@@ -299,6 +305,12 @@
     padding: 0.5em 1em;
     text-align: center;
     background-color: transparent;
+  }
+
+  @media (max-width: 36rem) {
+    .cmp-link-as-button {
+      padding: 0.25em 0.5em;
+    }
   }
 
   .cmp-link-as-button:hover,


### PR DESCRIPTION
This improves the mobile experience a bit, making it so that the letters and numbers don't wrap to two lines (except for very small screens). There's a bit of a trade-off with the touch target size, so it might be better to come up with alternatives, but I _think_ this will work okay.